### PR TITLE
syp_schedmaker: Unspecify canvas width

### DIFF
--- a/syp_schedmaker/index.js
+++ b/syp_schedmaker/index.js
@@ -830,7 +830,6 @@ $("#sciences select, #hummath select").each(function(){
 });
 $("#save").click(function(){
     html2canvas(document.getElementById("schedule"), {
-        width: 1000,
         background: "#ffffff",
         onrendered: function(c){
             var dataUrl = c.toDataURL(),


### PR DESCRIPTION
Specifying the canvas width to a constant of 1000px causes devices
of different screen widths to clip the resulting image.

Unspecifying the width will cause the resulting image to inherit
the device's screen width instead.